### PR TITLE
Rework SSH host key checking (v1.5.2)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    envirobly (1.5.1)
+    envirobly (1.5.2)
       activesupport (~> 8.0)
       aws-sdk-s3 (~> 1.182)
       concurrent-ruby (~> 1.3)

--- a/lib/envirobly/container_shell.rb
+++ b/lib/envirobly/container_shell.rb
@@ -8,7 +8,8 @@ class Envirobly::ContainerShell
   ]
   SSH = [
     "ssh -i %s",
-    "-o StrictHostKeyChecking=accept-new",
+    "-o StrictHostKeyChecking=no",
+    "-o UserKnownHostsFile=/dev/null",
     "-o SendEnv=ENVIROBLY_SERVICE_INTERACTIVE_SHELL",
     "-o SendEnv=ENVIROBLY_SERVICE_SHELL_USER",
     "-o ProxyCommand='aws ec2-instance-connect open-tunnel --instance-id %s --region %s'"
@@ -107,6 +108,6 @@ class Envirobly::ContainerShell
     end
 
     def user_and_host
-      sprintf USER_AND_HOST, connect_data.fetch("instance").fetch("public_ipv6")
+      sprintf USER_AND_HOST, connect_data.fetch("instance").fetch("private_ipv4")
     end
 end

--- a/lib/envirobly/version.rb
+++ b/lib/envirobly/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Envirobly
-  VERSION = "1.5.1"
+  VERSION = "1.5.2"
 end


### PR DESCRIPTION
To prevent errors with duplicate private subnet IPv4s in known_hosts
file. Strict security (against MITM attacks for example) is provided by
AWS instance connect instead.